### PR TITLE
seaborn 0.9 compatibility

### DIFF
--- a/anchor/visualize.py
+++ b/anchor/visualize.py
@@ -12,7 +12,7 @@ from .names import NEAR_ZERO, NEAR_HALF, NEAR_ONE, BIMODAL, \
     NULL_MODEL
 
 
-darkblue, green, red, purple, yellow, lightblue = sns.color_palette('deep')
+darkblue, orange, green, red, purple, brown, pink, gray, yellow, lightblue = sns.color_palette('deep')
 MODALITY_ORDER = [NEAR_ZERO, BIMODAL, NEAR_ONE, NEAR_HALF, NULL_MODEL]
 
 MODALITY_TO_COLOR = {NEAR_ZERO: lightblue, NEAR_HALF: yellow, NEAR_ONE: red,


### PR DESCRIPTION
Adds compatibility with new `seaborn` color palettes introduced in `0.9`. 

Since the colors are explicitly unpacked into individual variables, anyone running `0.9` gets a `ValueError` with the existing code.